### PR TITLE
Fix Python3 buffering warning

### DIFF
--- a/concurrencytest.py
+++ b/concurrencytest.py
@@ -69,7 +69,7 @@ def fork_for_tests(concurrency_num=CPU_COUNT):
             pid = os.fork()
             if pid == 0:
                 try:
-                    stream = os.fdopen(c2pwrite, 'wb', 1)
+                    stream = os.fdopen(c2pwrite, 'wb')
                     os.close(c2pread)
                     # Leave stderr and stdout open so we can see test noise
                     # Close stdin so that the child goes away if it decides to
@@ -93,7 +93,7 @@ def fork_for_tests(concurrency_num=CPU_COUNT):
                 os._exit(0)
             else:
                 os.close(c2pwrite)
-                stream = os.fdopen(c2pread, 'rb', 1)
+                stream = os.fdopen(c2pread, 'rb')
                 test = ProtocolTestCase(stream)
                 result.append(test)
         return result


### PR DESCRIPTION
This gives a warning in some situations:

/usr/lib/python3.10/os.py:1029: RuntimeWarning: line buffering
     (buffering=1) isn't supported in binary mode, the default buffer size
     will be used
  return io.open(fd, mode, buffering, encoding, *args, **kwargs)

Fix this by dropping the line-buffer parameter.