### PR TITLE
Add a TestResult.addDuration stub to silence warnings with Python 3.12+

### DIFF
--- a/concurrencytest.py
+++ b/concurrencytest.py
@@ -78,6 +78,13 @@ def fork_for_tests(concurrency_num=CPU_COUNT):
                     # child actually gets keystrokes for pdb etc).
                     sys.stdin.close()
                     subunit_result = AutoTimingTestResultDecorator(TestProtocolClient(stream))
+
+                    # Python 3.12 added unittest.TestResult.addDuration(), stub it out for now until 'subunit' supports it:
+                    # https://docs.python.org/3.12/library/unittest.html#unittest.TestResult.addDuration
+                    # https://github.com/testing-cabal/subunit/pull/85
+                    #
+                    subunit_result.addDuration = lambda _test, elapsed: None
+
                     process_suite.run(subunit_result)
                 except Exception:
                     # Try and report traceback on stream, but exit with error


### PR DESCRIPTION
See #16 

There is a pending PR to fix this in the `subunit` dependency: https://github.com/testing-cabal/subunit/pull/85

Once this is fixed in `subunit`, this code can be removed.
